### PR TITLE
Add convert2html binary with readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@
 # vendor/
 
 # geneated files durinb compile/build
-timeline2html/slowjam_full.html
-timeline2html/slowjam_simple.html
-timeline2html/timeline2html
+cmd/timeline2html/slowjam_full.html
+cmd/timeline2html/slowjam_simple.html
+cmd/timeline2html/timeline2html

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# geneated files durinb compile/build
+timeline2html/slowjam_full.html
+timeline2html/slowjam_simple.html
+timeline2html/timeline2html

--- a/cmd/timeline2html/README.md
+++ b/cmd/timeline2html/README.md
@@ -26,6 +26,11 @@ after runing your code. there will be a stack.log generated.
 ### convert stack.log to html
 
 - install timeline2html
+
+```
+go get -u github.com/google/slowjam/cmd/timeline2html
+```
+
 - run timeline2html
 
 ```

--- a/cmd/timeline2html/README.md
+++ b/cmd/timeline2html/README.md
@@ -1,0 +1,35 @@
+### example 
+
+### first add these lines to your main.go
+
+```
+package main
+
+import (
+    "github.com/google/slowjam/pkg/stacklog"
+    "github.com/pkg/profile"
+)
+
+func main() {
+		p := profile.Start(profile.TraceProfile, profile.NoShutdownHook)
+		defer p.Stop()
+		s, err := stacklog.Start(stacklog.Config{Path: "stack.log", Poll: 50 * time.Millisecond})
+		if err != nil {
+			panic("unable to log stacks")
+		}
+		defer s.Stop()
+}
+```
+
+after runing your code. there will be a stack.log generated.
+
+### convert stack.log to html
+
+- install timeline2html
+- run timeline2html
+
+```
+./timeline2html ./stack.log
+
+```
+this will generate two files slowjan_full.html and slowjam_simple.html

--- a/cmd/timeline2html/main.go
+++ b/cmd/timeline2html/main.go
@@ -51,8 +51,8 @@ func main() {
 
 	tl := stackparse.CreateTimeline(samples, stackparse.SuggestedIgnore)
 	tls := stackparse.SimplifyTimeline(tl)
-	GenerateHTML(tl, "full.html")
-	GenerateHTML(tls, "simple.html")
+	GenerateHTML(tl, "slowjam_full.html")
+	GenerateHTML(tls, "slowjam_simple.html")
 
 }
 

--- a/cmd/timeline2html/main.go
+++ b/cmd/timeline2html/main.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"image/color"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/maruel/panicparse/stack"
+	"golang.org/x/image/colornames"
+
+	"github.com/google/slowjam/pkg/stackparse"
+)
+
+var (
+	colorMap = map[string]color.RGBA{}
+)
+
+func main() {
+	flag.Parse()
+
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		panic(fmt.Sprintf("open: %v", err))
+	}
+
+	defer f.Close()
+	samples, err := stackparse.Read(f)
+	if err != nil {
+		panic(fmt.Sprintf("parse: %v", err))
+	}
+
+	tl := stackparse.CreateTimeline(samples, stackparse.SuggestedIgnore)
+	tls := stackparse.SimplifyTimeline(tl)
+	GenerateHTML(tl, "full.html")
+	GenerateHTML(tls, "simple.html")
+
+}
+
+func milliseconds(d time.Duration) string {
+	return fmt.Sprintf("%d", d.Milliseconds())
+}
+
+func creator(s *stack.Signature) string {
+	c := s.CreatedBy.Func.PkgDotName()
+	if c == "" {
+		c = "main"
+	}
+	return c
+}
+
+func height(ls []*stackparse.Layer) string {
+	return fmt.Sprintf("%d", 100+(35*len(ls)))
+}
+
+func updateColorMap(tl *stackparse.Timeline, cm map[string]color.RGBA) {
+	chosen := map[string]bool{}
+
+	for _, g := range tl.Goroutines {
+		for _, l := range g.Layers {
+			for _, c := range l.Calls {
+				_, ok := cm[c.Package]
+				if ok {
+					continue
+				}
+
+				// gimmick: try to find a similar name
+				for name, value := range colornames.Map {
+					if strings.Contains(name, "white") {
+						continue
+					}
+					if name[0] != c.Package[0] {
+						continue
+					}
+
+					if !chosen[name] {
+						chosen[name] = true
+						cm[c.Package] = value
+						break
+					}
+				}
+
+				_, ok = cm[c.Package]
+				if ok {
+					continue
+				}
+
+				// Giveup
+				for name, value := range colornames.Map {
+					if strings.Contains(name, "white") {
+						continue
+					}
+					if !chosen[name] {
+						chosen[name] = true
+						cm[c.Package] = value
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func callColor(pkg string, level int) string {
+	c := colorMap[pkg]
+	return fmt.Sprintf("#%02x%02x%02x", c.R, c.G, c.B)
+}
+
+// GenerateHTML generates an HTML file out of the stackparse.Timeline
+func GenerateHTML(tl *stackparse.Timeline, fileName string) {
+	updateColorMap(tl, colorMap)
+
+	glog.Infof("Timeline request coming in")
+
+	rc := struct {
+		Duration time.Duration
+		TL       *stackparse.Timeline
+	}{
+		Duration: tl.End.Sub(tl.Start),
+		TL:       tl,
+	}
+
+	f, err := os.Create(fileName)
+	defer f.Close()
+	if err != nil {
+		panic(fmt.Sprintf("open: %v", err))
+	}
+
+	err = reportTemplate.Execute(f, rc)
+	if err != nil {
+		panic(fmt.Sprintf("execute html: %v", err))
+	}
+
+}

--- a/cmd/timeline2html/template.go
+++ b/cmd/timeline2html/template.go
@@ -60,7 +60,7 @@ var reportTemplate = template.Must(template.New("SlowJamReportTemplate").Funcs(f
   </script>
 </head>
 <body>
-  <h1>SlowJam for {{ .Duration}} ({{ .TL.Samples }} samples) - <a href="/slowjam_full.html">full</a> | <a href="/slowjam_simple.html">simple</a></h1>
+  <h1>SlowJam for {{ .Duration}} ({{ .TL.Samples }} samples) - <a href="slowjam_full.html">full</a> | <a href="slowjam_simple.html">simple</a></h1>
   <div id="timeline" style="width: 3200px; height: 1024px;"></div>
 </body>
 </html>`))

--- a/cmd/timeline2html/template.go
+++ b/cmd/timeline2html/template.go
@@ -60,7 +60,7 @@ var reportTemplate = template.Must(template.New("SlowJamReportTemplate").Funcs(f
   </script>
 </head>
 <body>
-  <h1>SlowJam for {{ .Duration}} ({{ .TL.Samples }} samples) - <a href="/full.html">full</a> | <a href="/simple.html">simple</a></h1>
+  <h1>SlowJam for {{ .Duration}} ({{ .TL.Samples }} samples) - <a href="/slowjam_full.html">full</a> | <a href="/slowjam_simple.html">simple</a></h1>
   <div id="timeline" style="width: 3200px; height: 1024px;"></div>
 </body>
 </html>`))

--- a/cmd/timeline2html/template.go
+++ b/cmd/timeline2html/template.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "text/template"
+
+var fmap = template.FuncMap{
+	"Milliseconds": milliseconds,
+	"Creator":      creator,
+	"Height":       height,
+	"Color":        callColor,
+}
+
+// reportTemplate is the HTML template for the output report, to avoid compile issues embeding in the code
+var reportTemplate = template.Must(template.New("SlowJamReportTemplate").Funcs(fmap).Parse(`<html>
+<head>
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript">
+	google.charts.load('current', {'packages':['timeline']});
+
+	google.charts.setOnLoadCallback(drawTimeline);
+	function drawTimeline() {
+	  var container = document.getElementById('timeline');
+	  var chart = new google.visualization.Timeline(container);
+	  var dataTable = new google.visualization.DataTable();
+	  dataTable.addColumn({ type: 'string', id: 'Layer' });
+	  dataTable.addColumn({ type: 'string', id: 'Function' });
+	  dataTable.addColumn({ type: 'string', id: 'style', role: 'style' });
+	  dataTable.addColumn({ type: 'date', id: 'Start' });
+	  dataTable.addColumn({ type: 'date', id: 'End' });
+
+	  dataTable.addRows([
+		{{ range $g := .TL.Goroutines }}
+		  {{ range $index, $layer := .Layers}}
+			{{ range $layer.Calls }}
+			  [ '{{ $g.ID }}: {{ $g.Signature | Creator }}', '{{ .Name }}', '{{ Color .Package $index }}',  new Date({{ .StartDelta | Milliseconds }}), new Date({{ .EndDelta | Milliseconds }}) ],
+			{{ end }}
+		  {{ end }}
+		{{ end }}
+	  ]);
+	  var options = {
+		avoidOverlappingGridLines: false,
+	  };
+	  chart.draw(dataTable, options);
+	}
+  </script>
+</head>
+<body>
+  <h1>SlowJam for {{ .Duration}} ({{ .TL.Samples }} samples) - <a href="/full.html">full</a> | <a href="/simple.html">simple</a></h1>
+  <div id="timeline" style="width: 3200px; height: 1024px;"></div>
+</body>
+</html>`))

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/slowjam
+module github.com/medyagh/slowjam
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/slowjam v0.0.0-20200423205752-d32c9a66cc0c
 	github.com/maruel/panicparse v1.4.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/profile v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/maruel/panicparse v1.4.1
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
-	github.com/pkg/profile v1.4.0 // indirect
+	github.com/pkg/profile v1.4.0
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1
-	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/maruel/panicparse v1.4.1 h1:YtNovYb/yc/WVxRG4FH8cJb0JuZsysu3jqaOfSHsC+U=
 github.com/maruel/panicparse v1.4.1/go.mod h1:aOutY/MUjdj80R0AEVI9qE2zHqig+67t2ffUDDiLzAM=
@@ -17,4 +18,5 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/slowjam v0.0.0-20200423205752-d32c9a66cc0c h1:jhAMqhyhVTXtqFAWQL2hnyt+kK86Vy+sTs2xPjWu/qY=
+github.com/google/slowjam v0.0.0-20200423205752-d32c9a66cc0c/go.mod h1:O7o+62yhp7vBdnlmwgDjyQLouSUOaFZ1TArjQM2yQ8s=
 github.com/maruel/panicparse v1.4.1 h1:YtNovYb/yc/WVxRG4FH8cJb0JuZsysu3jqaOfSHsC+U=
 github.com/maruel/panicparse v1.4.1/go.mod h1:aOutY/MUjdj80R0AEVI9qE2zHqig+67t2ffUDDiLzAM=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
- add example without need to run webserver to be used in the CI
- see in action in this minikube's PR https://github.com/kubernetes/minikube/pull/8261

##### TODO:  revert gomod name back to google

once this PR is approved, the fork module name will be changed back to google/slowjam